### PR TITLE
build: Update architecture compiler flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,10 +81,10 @@ SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
 
 ifeq ($(DLDI_ARM9),1)
 DEFINES		+= -D__NDS__ -DARM9
-ARCH		:= -march=armv5te -mtune=arm946e-s
+ARCH		:= -mcpu=arm946e-s+nofp
 else
 DEFINES		+= -D__NDS__ -DARM7
-ARCH		:= -mcpu=arm7tdmi -mtune=arm7tdmi
+ARCH		:= -mcpu=arm7tdmi
 endif
 
 WARNFLAGS	:= -Wall


### PR DESCRIPTION
The new flags are the ones recommended for Wonderful Toolchain.

Also, ``-mtune=arm7tdmi`` is superfluous, so it has been removed.