### PR TITLE
card: Switch to using SPICNT macros

### DIFF
--- a/common/card.h
+++ b/common/card.h
@@ -6,7 +6,7 @@
 
 __attribute__((always_inline))
 static inline void card_enable(void) {
-    REG_AUXSPICNTH = CARD_CR1_ENABLE | CARD_CR1_IRQ;
+    REG_AUXSPICNTH = CARD_SPICNTH_ENABLE | CARD_SPICNTH_IRQ;
 }
 
 void card_read_aligned(void *buffer);


### PR DESCRIPTION
This aligns with the renaming of the CARD_CR1 register to REG_AUXSPICNT as of libnds commit e2a8242acde78c2fa65b467e799c3b96d841af52.